### PR TITLE
Document adding the file path of an object to the documentation

### DIFF
--- a/source/design/DataPackage.txt
+++ b/source/design/DataPackage.txt
@@ -213,6 +213,27 @@ increasing size.  Results are summarized below:
 .. TODO:  provide statistics for deserialization times for various size resource maps
 
 
+Describing filesystem hierarchies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The original on-disk location of an object that was uploaded to DataONE can be preserved in the resource map with
+``schema:contentUrl``. This allows for reconstruction of the uploader's package structure when
+downloading the package to disk.
+
+``schema:contentUrl`` expects a URL formatted string, which led to the decision of prepending the path with ``file://``.
+The path is relative to the ``data/`` directory in a bag archive, and can be thought of as being at the top level of a data package.
+
+For example, a file ``yearly_temps_2010.csv`` that resides in ``global_warming_metrics/data``
+can be described as::
+
+  <rdf:Description rdf:about="https://cn.dataone.org/cn/v1/resolve/pid">
+    <cito:isDocumentedBy rdf:resource="https://cn.dataone.org/cn/v2/resolve/"/>
+    <schema:contentUrl>./global_warming_metrics/data/yearly_temps_2010.csv</schema:contentUrl>
+    ...
+  </rdf:Description>
+
+When exported to a bag archive, its location would be ``./data/global_warming_metrics/data/``.
+
+
 Resource map validation
 -----------------------
 
@@ -674,6 +695,8 @@ structure of a bag is::
       ├── data-file-2.csv
       ├── data-file-3.hdf
       └── metadata-file-1.xml
+      └── analyses
+          └── script.R
 
 
 The first addition is the presence of an OAI-ORE document ``oai-ore.txt`` within
@@ -694,6 +717,7 @@ typical pid-mapping.txt file might contain::
   doi://10.xxxx/AA/TG43 data/data-file-1.csv
   doi://10.xxxx/AA/7AW3 data/data-file-2.csv
   doi://10.xxxx/AA/790I data/data-file-3.csv
+  doi://10.xxxx/AA/790I data/analyses/script.R
   doi://10.xxxx/AA/76AV data/metadata-file-1.xml
 
 The bag can be serialized as a single file for transport following the BagIt

--- a/source/design/DataPackage.txt
+++ b/source/design/DataPackage.txt
@@ -215,15 +215,17 @@ increasing size.  Results are summarized below:
 
 Describing filesystem hierarchies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The original on-disk location of an object that was uploaded to DataONE can be preserved in the resource map with
-``schema:contentUrl``. This allows for reconstruction of the uploader's package structure when
-downloading the package to disk.
+In some cases, data packages have scripts that depend on particular filesystem structures. For example, an ``analyze.R`` script may depend on 
+a file ``data/yearly_temps_2010.csv``. When packages are downloaded, the content is usually placed flat in the ``data/`` directory and the
+original path of the data is lost. This requires a researcher to manually reconstruct the folder structure of a bagged package.
+To remedy this, the original location of files that are uploaded to DataONE can be preserved in the resource map with
+``schema:contentUrl``. This allows for reconstruction of the uploader's package structure when exporting the package to a bag.
 
 ``schema:contentUrl`` expects a URL formatted string, which led to the decision of prepending the path with ``file://``.
 The path is relative to the ``data/`` directory in a bag archive, and can be thought of as being at the top level of a data package.
 
-For example, a file ``yearly_temps_2010.csv`` that resides in ``global_warming_metrics/data``
-can be described as::
+For example, a file ``yearly_temps_2010.csv`` that resides in a folder on a researchers' local machine at ``global_warming_metrics/data``
+can be described in DataONE as::
 
   <rdf:Description rdf:about="https://cn.dataone.org/cn/v1/resolve/pid">
     <cito:isDocumentedBy rdf:resource="https://cn.dataone.org/cn/v2/resolve/"/>
@@ -231,7 +233,19 @@ can be described as::
     ...
   </rdf:Description>
 
-When exported to a bag archive, its location would be ``./data/global_warming_metrics/data/``.
+When exported to a bag archive, a directory ``global_warming_metrics/data`` is created under the root ``data/`` directory. ``yearly_temps_2010.csv`` is placed
+under the newly created directories, shown below::
+
+  <base directory>/
+  ├── bagit.txt
+  ├── bag-info.txt
+  ├── manifest-<algorithm>.txt
+  ├── oai-ore.txt
+  ├── pid-mapping.txt
+  └── data
+      └── global_warming_metrics
+          └── data
+              └──yearly_temps_2010.csv
 
 
 Resource map validation

--- a/source/design/DataPackage.txt
+++ b/source/design/DataPackage.txt
@@ -219,17 +219,17 @@ In some cases, data packages have scripts that depend on particular filesystem s
 a file ``data/yearly_temps_2010.csv``. When packages are downloaded, the content is usually placed flat in the ``data/`` directory and the
 original path of the data is lost. This requires a researcher to manually reconstruct the folder structure of a bagged package.
 To remedy this, the original location of files that are uploaded to DataONE can be preserved in the resource map with
-``schema:contentUrl``. This allows for reconstruction of the uploader's package structure when exporting the package to a bag.
+``prov:atLocation``. This allows for reconstruction of the uploader's package structure when exporting the package to a bag.
 
-``schema:contentUrl`` expects a URL formatted string, which led to the decision of prepending the path with ``file://``.
-The path is relative to the ``data/`` directory in a bag archive, and can be thought of as being at the top level of a data package.
+``prov:atLocation`` has loose restrictions on the range of values that it can take. In DataONE's case, the value
+will be the path of the file relative to the package root.
 
 For example, a file ``yearly_temps_2010.csv`` that resides in a folder on a researchers' local machine at ``global_warming_metrics/data``
-can be described in DataONE as::
+is described in DataONE as::
 
   <rdf:Description rdf:about="https://cn.dataone.org/cn/v1/resolve/pid">
     <cito:isDocumentedBy rdf:resource="https://cn.dataone.org/cn/v2/resolve/"/>
-    <schema:contentUrl>./global_warming_metrics/data/yearly_temps_2010.csv</schema:contentUrl>
+    <prov:atLocation>global_warming_metrics/data/yearly_temps_2010.csv</prov:atLocation>
     ...
   </rdf:Description>
 


### PR DESCRIPTION
### Background

It would be nice if we could export bags that reflect the original directory structure. It would also be nice if we could show in the UI where the files were when they were on the researcher's disk (or maybe in a zip file). To do so, we need to add a term to the resource map that allows us to encode this information.

### Solution
I propose that we use [prov:atLocation](https://www.w3.org/TR/prov-o/#atLocation) as the word which describes the path.
For example, `<prov:atLocation>chemical_data/classes.csv</prov:atLocation>`


```
    <rdf:Description rdf:about="https://cn.dataone.org/cn/v2/resolve/test.1.1">
        <dcterms:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test.1.1</dcterms:identifier>
        <cito:isDocumentedBy rdf:resource="https://cn.dataone.org/cn/v2/resolve/sys_meta_pid2999"/>
        <ore:isAggregatedBy rdf:resource="https://cn.dataone.org/cn/v2/resolve/resmap_pid_49999#aggregation"/>
        <prov:atLocation>chemical_data/classes.csv</prov:atLocation>
    </rdf:Description>
```

It's important to note that the path is relative to the data package root, and _does not_ include `file://`

#### Outdated Solution
I propose that we use [schema:contentUrl](https://schema.org/contentUrl) as the word which describes the path.
For example, `<schema:contentUrl>file://./chemical_data/classes.csv</schema:contentUrl>`

Staying true to the `contentUrl` property, the URL is prepended with `file://`, and the path is independent of the bag structure (it's not `file://data/......`. I decided to keep it independent of the bag path to keep it more general for use in the UI. `./` can be thought of as the top level, with nothing existing higher. When the bag is constructed, everything within `./` is placed in the `data/` directory.

[This](https://dev.nceas.ucsb.edu/view/sys_meta_pid2999) package has an RDF description of `classes.csv` that didn't seem to break anything.

```
    <rdf:Description rdf:about="https://cn.dataone.org/cn/v2/resolve/test.1.1">
        <dcterms:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string">test.1.1</dcterms:identifier>
        <cito:isDocumentedBy rdf:resource="https://cn.dataone.org/cn/v2/resolve/sys_meta_pid2999"/>
        <ore:isAggregatedBy rdf:resource="https://cn.dataone.org/cn/v2/resolve/resmap_pid_49999#aggregation"/>
        <schema:contentUrl>file://./chemical_data/classes.csv</schema:contentUrl>
    </rdf:Description>
```

### To Do

- [x] Expand on use case & make it more clear that the path is original path on the researchers' computer

We briefly mentioned this in the DataONE call however, I'll tag @mbjones since he'll be interested in this development as well.